### PR TITLE
Bump Go to `1.24` and libdns to `0.2.3`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/template
 
-go 1.18
+go 1.24
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.3 h1:ba30K4ObwMGB/QTmqUxf3H4/GmUrCAIkMWejeGl12v8=
+github.com/libdns/libdns v0.2.3/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=


### PR DESCRIPTION
Just upgrading some versions in the template, will open a follow-up in `caddy-dns/template` as well.