### PR TITLE
feat: implement libdns provider for ConoHa VPS Ver.3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) msshtdev
+Copyright (c) 2025 msshtdev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <TODO: YEAR AND NAME>
+Copyright (c) msshtdev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ p := conohav3.Provider{
     APITenantID: "apiTenantID",
     APIUserID: "apiUserID",
     APIPassword: "apiPassword",
-    Region: "region", // optional default value is "c3j1"
+    Region: "region", // Optional. If omitted, defaults to "c3j1".
 }
 zone := `example.localhost`
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,42 @@
-DEVELOPER INSTRUCTIONS:
-=======================
+# ConoHa VPS Ver 3.0 for `libdns`
 
-This repo is a template for developers to use when creating new [libdns](https://github.com/libdns/libdns) provider implementations.
+This package implements the [libdns interface](https://github.com/libdns/libdns) for [ConoHa VPS Ver.3.0](https://doc.conoha.jp/products/vps-v3/) using [ConoHa VPS Ver.3.0 Public APIs](https://doc.conoha.jp/reference/api-vps3/).
 
-Be sure to update:
+## Authenticating
 
-- The package name
-- The Go module name in go.mod
-- The latest `libdns/libdns` version in go.mod
-- All comments and documentation, including README below and godocs
-- License (must be compatible with Apache/MIT)
-- All "TODO:"s is in the code
-- All methods that currently do nothing
+The `conohav3` package authenticates using the credentials required by ConoHa's Identity API.
 
-**Please be sure to conform to the semantics described at the [libdns godoc](https://github.com/libdns/libdns).**
+You must provide the following variables:
 
-_Remove this section from the readme before publishing._
+- **APITenantID**: Your ConoHa **Tenant ID** . This identifies your account's tenant.
+- **APIUserID**: Your **User ID** associated with the API credentials.
+- **APIPassword**: The **User Password** for the user.
+- **Region** *(optional)*: The ConoHa service region. If omitted, defaults to `"c3j1"`.
 
----
+These credentials are used to obtain a token from the Identity service, which is then used to authorize DNS API requests.
 
-\<PROVIDER NAME\> for [`libdns`](https://github.com/libdns/libdns)
-=======================
+See [Identity APIs](https://doc.conoha.jp/reference/api-vps3/api-identity-vps3/identity-post_tokens-v3/) for more details.
 
-[![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/TODO:PROVIDER_NAME)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns) for \<PROVIDER\>, allowing you to manage DNS records.
+## Example Configuration
 
-TODO: Show how to configure and use. Explain any caveats.
+```go
+p := conohav3.Provider{
+    APITenantID: "apiTenantID",
+    APIUserID: "apiUserID",
+    APIPassword: "apiPassword",
+    Region: "region", // optional default value is "c3j1"
+}
+zone := `example.localhost`
+
+// List existing records
+fmt.Printf("List existing records\n")
+currentRecords, err := conohav3.GetRecords(context.TODO(), zone)
+if err != nil {
+    fmt.Printf("%v\n", err)
+	return
+}
+for _, record := range currentRecords {
+	fmt.Printf("Exists: %v\n", record)
+}
+```

--- a/client.go
+++ b/client.go
@@ -1,0 +1,231 @@
+package conohav3
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const dnsServiceBaseURL = "https://dns-service.%s.conoha.io"
+
+// dnsClient is a ConoHa API client for DNS service.
+type dnsClient struct {
+	token string
+
+	baseURL    *url.URL
+	HTTPClient *http.Client
+}
+
+// newDnsClient returns a client for DNS service instance logged into the ConoHa service.
+func newDnsClient(region, token string) (*dnsClient, error) {
+	if region == "" {
+		region = "c3j1"
+	}
+
+	baseURL, err := url.Parse(fmt.Sprintf(dnsServiceBaseURL, region))
+	if err != nil {
+		return nil, err
+	}
+
+	return &dnsClient{
+		token:      token,
+		baseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+	}, nil
+}
+
+// getDomainID returns an ID of specified domain.
+func (c *dnsClient) getDomainID(ctx context.Context, domainName string) (string, error) {
+	domainList, err := c.getDomains(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for _, domain := range domainList.Domains {
+		if domain.Name == domainName {
+			return domain.UUID, nil
+		}
+	}
+
+	return "", fmt.Errorf("no such domain: %s", domainName)
+}
+
+// getDomains returns a list of domains registered in DNS.
+// https://doc.conoha.jp/reference/api-vps3/api-dns-vps3/dnsaas-get_domains_list-v3/?btn_id=reference-api-vps3--sidebar_reference-dnsaas-get_domains_list-v3
+func (c *dnsClient) getDomains(ctx context.Context) (*domainListResponse, error) {
+	endpoint := c.baseURL.JoinPath("v1", "domains")
+
+	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	domainList := &domainListResponse{}
+
+	err = c.do(req, domainList)
+	if err != nil {
+		return nil, err
+	}
+
+	return domainList, nil
+}
+
+// getRecordID returns an ID of specified record.
+func (c *dnsClient) getRecordID(ctx context.Context, domainID, recordName, recordType string) (string, error) {
+	recordList, err := c.getRecords(ctx, domainID)
+	if err != nil {
+		return "", err
+	}
+
+	for _, record := range recordList.Records {
+		if record.Name == recordName && record.Type == recordType {
+			return record.UUID, nil
+		}
+	}
+
+	return "", errRecordNotFound
+}
+
+// getRecords returns a list of records registered for the domain identified by the domainID.
+// https://doc.conoha.jp/reference/api-vps3/api-dns-vps3/dnsaas-get_records_list-v3/?btn_id=reference-dnsaas-get_domains_list-v3--sidebar_reference-dnsaas-get_records_list-v3
+func (c *dnsClient) getRecords(ctx context.Context, domainID string) (*recordListResponse, error) {
+	endpoint := c.baseURL.JoinPath("v1", "domains", domainID, "records")
+
+	req, err := newJSONRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	recordList := &recordListResponse{}
+
+	err = c.do(req, recordList)
+	if err != nil {
+		return nil, err
+	}
+
+	return recordList, nil
+}
+
+// createRecord adds new record.
+// https://doc.conoha.jp/reference/api-vps3/api-dns-vps3/dnsaas-create_record-v3/?btn_id=reference-dnsaas-get_records_list-v3--sidebar_reference-dnsaas-create_record-v3
+func (c *dnsClient) createRecord(ctx context.Context, domainID string, record conohaDNSRecord) (*conohaDNSRecord, error) {
+	endpoint := c.baseURL.JoinPath("v1", "domains", domainID, "records")
+
+	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, record)
+	if err != nil {
+		return nil, err
+	}
+
+	newRecord := &conohaDNSRecord{}
+
+	err = c.do(req, newRecord)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRecord, nil
+}
+
+// updateRecord update specified record.
+// https://doc.conoha.jp/reference/api-vps3/api-dns-vps3/dnsaas-update_record-v3/?btn_id=reference-dnsaas-update_record-v3--sidebar_reference-dnsaas-update_record-v3
+func (c *dnsClient) updateRecord(ctx context.Context, domainID string, recordID string, record conohaDNSRecord) (*conohaDNSRecord, error) {
+	endpoint := c.baseURL.JoinPath("v1", "domains", domainID, "records", recordID)
+	// NOTE: ConoHa's DNS API inconsistently may handle the `ttl` field:
+	//       - `ttl` is accepted in record creation (POST), even though it's undocumented.
+	//       - `ttl` causes a 400 error during update (PUT), even if set to the same value.
+	//       As a workaround, we zero-out TTL on updates to suppress the field via `omitempty`.
+	//       This should be revisited if the API adds consistent TTL support for updates.
+
+	record.TTL = 0
+
+	req, err := newJSONRequest(ctx, http.MethodPut, endpoint, record)
+	if err != nil {
+		return nil, err
+	}
+
+	newRecord := &conohaDNSRecord{}
+	err = c.do(req, newRecord)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRecord, nil
+}
+
+// DeleteRecord removes specified record.
+// https://doc.conoha.jp/reference/api-vps3/api-dns-vps3/dnsaas-delete_record-v3/?btn_id=reference-dnsaas-create_record-v3--sidebar_reference-dnsaas-delete_record-v3
+func (c *dnsClient) deleteRecord(ctx context.Context, domainID, recordID string) error {
+	endpoint := c.baseURL.JoinPath("v1", "domains", domainID, "records", recordID)
+
+	req, err := newJSONRequest(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.do(req, nil)
+}
+
+// do sends an HTTP request and optionally decodes the JSON response into the provided result.
+func (c *dnsClient) do(req *http.Request, result any) error {
+	if c.token != "" {
+		req.Header.Set("X-Auth-Token", c.token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("got error status: HTTP %d\nResponse body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	if result == nil {
+		return nil
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(raw, result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newJSONRequest creates a new HTTP request with a JSON-encoded payload.
+func newJSONRequest(ctx context.Context, method string, endpoint *url.URL, payload any) (*http.Request, error) {
+	buf := new(bytes.Buffer)
+
+	if payload != nil {
+		err := json.NewEncoder(buf).Encode(payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request JSON body: %w", err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), buf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}

--- a/conohav3.go
+++ b/conohav3.go
@@ -1,0 +1,74 @@
+package conohav3
+
+import "errors"
+
+// identityRequest is the top-level payload sent to the Identity v3.
+type identityRequest struct {
+	Auth auth `json:"auth"`
+}
+
+// auth authentication credentials (identity) and scope (scope).
+type auth struct {
+	Identity identity `json:"identity"`
+	Scope    scope    `json:"scope"`
+}
+
+// identity describes how the client will authenticate.
+// In ConoHa VPS VER.3.0, only support the "password" method.
+type identity struct {
+	Methods  []string `json:"methods"`
+	Password password `json:"password"`
+}
+
+// password nests the concrete user credentials used by the password auth method.
+type password struct {
+	User user `json:"user"`
+}
+
+// user holds the API User ID and password that will be verified by the Identity service.
+type user struct {
+	ID       string `json:"id"`
+	Password string `json:"password"`
+}
+
+// scope specifies which tenant the issued token should be scoped to.
+type scope struct {
+	Project project `json:"project"`
+}
+
+// project identifies the target tenant by UUID.
+type project struct {
+	ID string `json:"id"`
+}
+
+// domainListResponse is returned by `GET /v1/domains` and contains all DNS zones (domains) owned by the project.
+type domainListResponse struct {
+	Domains []domain `json:"domains"`
+}
+
+// domain represents a single hosted DNS zone.
+type domain struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
+// recordListResponse is returned by `GET /v1/domains/{domain_uuid}/records` and lists every record in the zone.
+type recordListResponse struct {
+	Records []conohaDNSRecord `json:"records"`
+}
+
+// conohaDNSRecord represents a DNS record inside a zone.
+// NOTE: TTL is marked with `omitempty` because:
+// - The ConoHa API accepts `ttl` in POST (record creation), even though it's undocumented.
+// - The API rejects `ttl` in PUT (record update), returning HTTP 400.
+// This design ensures TTL is included only when non-zero (typically during creation).
+type conohaDNSRecord struct {
+	UUID string `json:"uuid,omitempty"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Data string `json:"data"`
+	TTL  int    `json:"ttl,omitempty"` // TTL is readonly on update — see note above.
+}
+
+var errRecordNotFound = errors.New("Record not found")
+var errRecordNotSupported = errors.New("Record Type is not supported")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/libdns/template
+module github.com/msshtdev/conohav3
 
 go 1.18
 
-require github.com/libdns/libdns v1.0.0
+require github.com/libdns/libdns v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
-github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/identity.go
+++ b/identity.go
@@ -1,0 +1,85 @@
+package conohav3
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const identityBaseURL = "https://identity.%s.conoha.io"
+
+type identifier struct {
+	baseURL    *url.URL
+	HTTPClient *http.Client
+}
+
+// newIdentifier creates a new Identifier.
+func newIdentifier(region string) (*identifier, error) {
+	if region == "" {
+		region = "c3j1"
+	}
+
+	baseURL, err := url.Parse(fmt.Sprintf(identityBaseURL, region))
+	if err != nil {
+		return nil, err
+	}
+
+	return &identifier{
+		baseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+	}, nil
+}
+
+// getToken returns a x-subject-token from Identity API.
+// https://doc.conoha.jp/reference/api-vps3/api-identity-vps3/identity-post_tokens-v3/?btn_id=reference-api-guideline-v3--sidebar_reference-identity-post_tokens-v3
+func (c *identifier) getToken(ctx context.Context, APITenantID, APIUserID, APIPassword string) (string, error) {
+	auth := auth{
+		Identity: identity{
+			Methods: []string{"password"},
+			Password: password{
+				User: user{
+					ID:       APIUserID,
+					Password: APIPassword,
+				},
+			},
+		},
+		Scope: scope{
+			Project: project{
+				ID: APITenantID,
+			},
+		},
+	}
+	endpoint := c.baseURL.JoinPath("v3", "auth", "tokens")
+
+	req, err := newJSONRequest(ctx, http.MethodPost, endpoint, &identityRequest{Auth: auth})
+	if err != nil {
+		return "", err
+	}
+
+	return c.do(req)
+}
+
+// do sends a request and returns a token from x-subject-token header.
+func (c *identifier) do(req *http.Request) (string, error) {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("got invalid status: HTTP %d", resp.StatusCode)
+	}
+
+	token := resp.Header.Get("x-subject-token")
+	if token == "" {
+		return "", fmt.Errorf("x-subject-token header is missing in response")
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	return token, nil
+}

--- a/provider.go
+++ b/provider.go
@@ -1,52 +1,255 @@
-// Package libdnstemplate implements a DNS record management client compatible
-// with the libdns interfaces for <PROVIDER NAME>. TODO: This package is a
-// template only. Customize all godocs for actual implementation.
-package libdnstemplate
+package conohav3
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/netip"
+	"sync"
+	"time"
 
 	"github.com/libdns/libdns"
 )
 
-// TODO: Providers must not require additional provisioning steps by the callers; it
-// should work simply by populating a struct and calling methods on it. If your DNS
-// service requires long-lived state or some extra provisioning step, do it implicitly
-// when methods are called; sync.Once can help with this, and/or you can use a
-// sync.(RW)Mutex in your Provider struct to synchronize implicit provisioning.
-
-// Provider facilitates DNS record manipulation with <TODO: PROVIDER NAME>.
+// Provider facilitates DNS record management using the ConoHa VPS API (v3.0).
+// It implements the libdns interfaces for getting, appending, setting, and deleting DNS records.
 type Provider struct {
-	// TODO: Put config fields here (with snake_case json struct tags on exported fields), for example:
-	APIToken string `json:"api_token,omitempty"`
+	APITenantID string `json:"api_tenant_id,omitempty"` // ConoHa API tenant ID
+	APIUserID   string `json:"api_user_id,omitempty"`   // ConoHa API user ID
+	APIPassword string `json:"api_password,omitempty"`  // ConoHa API password
+	Region      string `json:"region,omitempty"`        // ConoHa API region (e.g. "c3j1")
 
-	// Exported config fields should be JSON-serializable or omitted (`json:"-"`)
+	mutex sync.Mutex
 }
 
-// GetRecords lists all the records in the zone.
+// initClient initializes a new DNS API client with an authentication token.
+func (p *Provider) initClient(ctx context.Context) (*dnsClient, error) {
+	identifier, err := newIdentifier(p.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := identifier.getToken(ctx, p.APITenantID, p.APIUserID, p.APIPassword)
+	if err != nil {
+		return nil, err
+	}
+
+	return newDnsClient(p.Region, token)
+}
+
+// GetRecords lists all the DNS records in the specified zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	dnsClient, err := p.initClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	domainID, err := dnsClient.getDomainID(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	rawRecordList, err := dnsClient.getRecords(ctx, domainID)
+	if err != nil {
+		return nil, err
+	}
+
+	var libRecords []libdns.Record
+	for _, record := range rawRecordList.Records {
+		libRecord, err := convertToLibdnsRecord(record)
+		if err != nil {
+			if err == errRecordNotSupported {
+				continue
+			}
+			return nil, err
+		}
+		libRecords = append(libRecords, libRecord)
+	}
+
+	return libRecords, nil
 }
 
-// AppendRecords adds records to the zone. It returns the records that were added.
+// AppendRecords adds the specified records to the zone.
+// It returns the successfully added records.
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	dnsClient, err := p.initClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	domainID, err := dnsClient.getDomainID(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rec := range records {
+		rawRecord, err := convertToConohaDNSRecord(rec)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = dnsClient.createRecord(ctx, domainID, rawRecord)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return records, nil
 }
 
-// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
-// It returns the updated records.
+// SetRecords sets the records in the zone, updating existing ones or creating new ones.
+// It returns the records that were updated or added.
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	dnsClient, err := p.initClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	domainID, err := dnsClient.getDomainID(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rec := range records {
+		converted, err := convertToConohaDNSRecord(rec)
+		if err != nil {
+			return nil, err
+		}
+
+		recordID, err := dnsClient.getRecordID(ctx, domainID, converted.Name, converted.Type)
+		if err != nil {
+			if errors.Is(err, errRecordNotFound) {
+				_, err = dnsClient.createRecord(ctx, domainID, converted)
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+
+		_, err = dnsClient.updateRecord(ctx, domainID, recordID, converted)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return records, nil
 }
 
-// DeleteRecords deletes the specified records from the zone. It returns the records that were deleted.
+// DeleteRecords deletes the specified records from the zone.
+// It returns the records that were successfully deleted.
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	dnsClient, err := p.initClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	domainID, err := dnsClient.getDomainID(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rec := range records {
+		converted, err := convertToConohaDNSRecord(rec)
+		if err != nil {
+			return nil, err
+		}
+
+		recordID, err := dnsClient.getRecordID(ctx, domainID, converted.Name, converted.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := dnsClient.deleteRecord(ctx, domainID, recordID); err != nil {
+			return nil, err
+		}
+	}
+
+	return records, nil
+}
+
+// convertToLibdnsRecord converts a raw API record to a libdns-compatible record.
+func convertToLibdnsRecord(rec conohaDNSRecord) (libdns.Record, error) {
+	ttl := time.Duration(rec.TTL) * time.Second
+
+	switch rec.Type {
+	case "A", "AAAA":
+		ip, err := netip.ParseAddr(rec.Data)
+		if err != nil {
+			return nil, err
+		}
+		return libdns.Address{
+			Name: rec.Name,
+			TTL:  ttl,
+			IP:   ip,
+		}, nil
+	case "CNAME":
+		return libdns.CNAME{
+			Name:   rec.Name,
+			TTL:    ttl,
+			Target: rec.Data,
+		}, nil
+	case "TXT":
+		return libdns.TXT{
+			Name: rec.Name,
+			TTL:  ttl,
+			Text: rec.Data,
+		}, nil
+	default:
+		return nil, errRecordNotSupported
+	}
+}
+
+// convertToConohaDNSRecord converts a libdns.Record into a ConoHa-compatible raw Record struct.
+func convertToConohaDNSRecord(rec libdns.Record) (conohaDNSRecord, error) {
+	rr := rec.RR()
+	parsed, err := rr.Parse()
+	if err != nil {
+		return conohaDNSRecord{}, fmt.Errorf("failed to parse record: %w", err)
+	}
+
+	if parsed == nil {
+		return conohaDNSRecord{}, fmt.Errorf("record is nil after parsing: %v", rec)
+	}
+
+	switch r := parsed.(type) {
+	case libdns.Address:
+		return conohaDNSRecord{
+			Name: r.Name,
+			Type: rr.Type,
+			Data: r.IP.String(),
+			TTL:  int(r.TTL.Seconds()),
+		}, nil
+	case libdns.CNAME:
+		return conohaDNSRecord{
+			Name: r.Name,
+			Type: rr.Type,
+			Data: r.Target,
+			TTL:  int(r.TTL.Seconds()),
+		}, nil
+	case libdns.TXT:
+		return conohaDNSRecord{
+			Name: r.Name,
+			Type: rr.Type,
+			Data: r.Text,
+			TTL:  int(r.TTL.Seconds()),
+		}, nil
+	default:
+		return conohaDNSRecord{}, errRecordNotSupported
+	}
 }
 
 // Interface guards

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,153 @@
+package conohav3
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
+var (
+	apiTenantID = ""
+	apiUserID   = ""
+	apiPassword = ""
+	zone        = ""
+	testRecords = []libdns.Record{}
+)
+
+func TestMain(m *testing.M) {
+	fmt.Println("Loading environment variables to set up provider")
+	apiTenantID = os.Getenv("API_TENANT_ID")
+	apiUserID = os.Getenv("API_USER_ID")
+	apiPassword = os.Getenv("API_PASSWORD")
+	zone = os.Getenv("ZONE")
+	testRecords = []libdns.Record{
+		libdns.TXT{
+			Name: "test." + zone,
+			Text: "testval1",
+			TTL:  time.Duration(1200) * time.Second,
+		},
+	}
+
+	os.Exit(m.Run())
+}
+
+func setupTestRecords(t *testing.T, p *Provider) []libdns.Record {
+	fmt.Println("Appending test records")
+	records, err := p.AppendRecords(context.TODO(), zone, testRecords)
+	if err != nil {
+		t.Fatalf("Setup failed: %v", err)
+		return nil
+	}
+	return records
+}
+
+func cleanupRecords(t *testing.T, p *Provider, records []libdns.Record) {
+	fmt.Println("Cleaning up test records")
+	if _, err := p.DeleteRecords(context.TODO(), zone, records); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+}
+
+func isSameRecord(a libdns.Record, b libdns.Record) bool {
+	rawa, _ := convertToConohaDNSRecord(a)
+	rawb, _ := convertToConohaDNSRecord(b)
+
+	// NOTE: We intentionally do not compare TTL values here.
+	// ConoHa's API does not consistently preserve or allow updates to TTL,
+	// especially during record updates, where TTL may be omitted or reset.
+	// Comparing TTL would cause false mismatches in those cases.
+
+	return rawa.Name == rawb.Name && rawa.Type == rawb.Type && rawa.Data == rawb.Data
+}
+
+func TestProvider_GetRecords(t *testing.T) {
+	fmt.Println("Test GetRecords")
+
+	p := &Provider{
+		APITenantID: apiTenantID,
+		APIUserID:   apiUserID,
+		APIPassword: apiPassword,
+	}
+
+	setupRecords := setupTestRecords(t, p)
+	defer cleanupRecords(t, p, setupRecords)
+
+	records, err := p.GetRecords(context.TODO(), zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testRec := range testRecords {
+		found := false
+		for _, rec := range records {
+			if isSameRecord(testRec, rec) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("testRecord not found: %+v", testRec)
+		}
+	}
+}
+
+func TestProvider_SetProvider(t *testing.T) {
+	fmt.Println("Test SetRecords")
+
+	p := &Provider{
+		APITenantID: apiTenantID,
+		APIUserID:   apiUserID,
+		APIPassword: apiPassword,
+	}
+
+	setupRecords := setupTestRecords(t, p)
+	defer cleanupRecords(t, p, setupRecords)
+
+	var newTestRecords []libdns.Record
+	newData := "updated"
+	newTTL := 1200
+
+	for _, testRec := range testRecords {
+		rawRec, err := convertToConohaDNSRecord(testRec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rawRec.Data = newData
+		rawRec.TTL = newTTL
+
+		newRec, err := convertToLibdnsRecord(rawRec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newTestRecords = append(newTestRecords, newRec)
+	}
+
+	_, err := p.SetRecords(context.TODO(), zone, newTestRecords)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := p.GetRecords(context.TODO(), zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testRec := range newTestRecords {
+		found := false
+		for _, rec := range records {
+			if isSameRecord(testRec, rec) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("testRecord not found: %+v", testRec)
+		}
+	}
+}


### PR DESCRIPTION
Hi, I've  implemented a DNS provider for [ConoHa VPS](https://www.conoha.jp/vps/?btn_id=login--commonHeader_vps-top) using the [ConoHa VPS API Ver.3.0](https://doc.conoha.jp/reference/api-vps3/).

## Issue:

https://github.com/libdns/libdns/issues/184

## Summary of changes:
```
- Added support for libdns.Record operations via ConoHa VPS Ver.3.0 Public APIs
- Implemented authentication using Identity (tenant ID, user ID, user password)
- Handled region fallback to default ("c3j1") if unspecified
- Included TTL workaround due to ConoHa API inconsistencies (POST allows, PUT rejects)
- Added integration with libdns interface: Get, Append, Set, and DeleteRecords
- Provided README with usage and authentication instructions
```
## Test output:
```bash
msshta@dev:~/Documents/github/caddys/libdns/libdns-provider-for-conohav3$ env $(cat .env | xargs) go test . -v -count=1
Loading environment variables to set up provider
=== RUN   TestProvider_GetRecords
Test GetRecords
Appending test records
Cleaning up test records
--- PASS: TestProvider_GetRecords (8.55s)
=== RUN   TestProvider_SetProvider
Test SetRecords
Appending test records
Cleaning up test records
--- PASS: TestProvider_SetProvider (9.46s)
PASS
ok      github.com/msshtdev/conohav3    18.017s
msshta@dev:~/Documents/github/caddys/libdns/libdns-provider-for-conohav3$

```

Let me know if there’s anything I should improve or adjust — thanks in advance!