### PR TITLE
Implement libdns to connect to TLH API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <TODO: YEAR AND NAME>
+Copyright (c) 2026 The Little Host
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,29 +1,59 @@
-DEVELOPER INSTRUCTIONS:
-=======================
+The Little Host for [`libdns`](https://github.com/libdns/libdns)
+==================================================================
 
-This repo is a template for developers to use when creating new [libdns](https://github.com/libdns/libdns) provider implementations.
+[![Go Reference](https://pkg.go.dev/badge/github.com/libdns/thelittlehost.svg)](https://pkg.go.dev/github.com/libdns/thelittlehost)
 
-Be sure to update:
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for [The Little Host](https://thelittlehost.com), allowing you to manage DNS records programmatically.
 
-- The package name
-- The Go module name in go.mod
-- The latest `libdns/libdns` version in go.mod
-- All comments and documentation, including README below and godocs
-- License (must be compatible with Apache/MIT)
-- All "TODO:"s is in the code
-- All methods that currently do nothing
+## Configuration
 
-**Please be sure to conform to the semantics described at the [libdns godoc](https://github.com/libdns/libdns).**
+```go
+provider := &thelittlehost.Provider{
+    APIToken: "tlh_your_api_token_here",
+}
+```
 
-_Remove this section from the readme before publishing._
+### Fields
 
----
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `APIToken` | `string` | **Yes** | Bearer token for API authentication. Generate one in the The Little Host control panel. Tokens are prefixed with `tlh_`. |
 
-\<PROVIDER NAME\> for [`libdns`](https://github.com/libdns/libdns)
-=======================
+### Environment variables
 
-[![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/TODO:PROVIDER_NAME)
+This package does not read environment variables directly. Set struct fields explicitly, or use environment variables as defaults in your application:
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns) for \<PROVIDER\>, allowing you to manage DNS records.
+```go
+provider := &thelittlehost.Provider{
+    APIToken: os.Getenv("THELITTLEHOST_API_TOKEN"),
+}
+```
 
-TODO: Show how to configure and use. Explain any caveats.
+## Usage with CertMagic / Caddy
+
+```go
+import "github.com/libdns/thelittlehost"
+
+provider := &thelittlehost.Provider{
+    APIToken: "tlh_...",
+}
+```
+
+In Caddy JSON config:
+
+```json
+{
+  "module": "thelittlehost",
+  "api_token": "tlh_..."
+}
+```
+
+## Caveats
+
+- **MX records**: Priority is encoded in the `Data` field as `"<preference> <target>"` per the libdns convention and is split out for the API automatically.
+- **DeleteRecords wildcards**: Empty `Type`, `TTL`, or `Data` fields on an input record act as wildcards — any existing record matching the non-empty fields will be deleted.
+- **Concurrency**: All methods are safe for concurrent use.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/libdns/template
+module github.com/libdns/thelittlehost
 
-go 1.18
+go 1.22
 
-require github.com/libdns/libdns v1.0.0
+require github.com/libdns/libdns v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v1.0.0 h1:IvYaz07JNz6jUQ4h/fv2R4sVnRnm77J/aOuC9B+TQTA=
-github.com/libdns/libdns v1.0.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.1.1 h1:wPrHrXILoSHKWJKGd0EiAVmiJbFShguILTg9leS/P/U=
+github.com/libdns/libdns v1.1.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/provider.go
+++ b/provider.go
@@ -1,52 +1,452 @@
-// Package libdnstemplate implements a DNS record management client compatible
-// with the libdns interfaces for <PROVIDER NAME>. TODO: This package is a
-// template only. Customize all godocs for actual implementation.
-package libdnstemplate
+// Package thelittlehost implements a DNS record management client compatible
+// with the libdns interfaces for The Little Host DNS API.
+package thelittlehost
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/libdns/libdns"
 )
 
-// TODO: Providers must not require additional provisioning steps by the callers; it
-// should work simply by populating a struct and calling methods on it. If your DNS
-// service requires long-lived state or some extra provisioning step, do it implicitly
-// when methods are called; sync.Once can help with this, and/or you can use a
-// sync.(RW)Mutex in your Provider struct to synchronize implicit provisioning.
+// apiRecord represents a DNS record as returned by The Little Host API.
+// Note: the API accepts "record_type" in requests but returns "type" in responses.
+type apiRecord struct {
+	ID       int    `json:"id"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	TTL      int    `json:"ttl"`
+	Priority *int   `json:"priority,omitempty"`
+}
 
-// Provider facilitates DNS record manipulation with <TODO: PROVIDER NAME>.
+// recordInput represents the fields for creating or updating a record.
+// Note: removed omitempty from the TTL json field as it returns a nil when
+// TTL=0
+type recordInput struct {
+	RecordType string `json:"record_type,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Value      string `json:"value,omitempty"`
+	TTL        int    `json:"ttl"`
+	Priority   *int   `json:"priority,omitempty"`
+}
+
+// recordRequest wraps a recordInput for the API request body.
+type recordRequest struct {
+	Record recordInput `json:"record"`
+}
+
+// rrsetKey uniquely identifies an RRset by name and type.
+type rrsetKey struct {
+	Name string
+	Type string
+}
+
+// Provider facilitates DNS record manipulation with The Little Host.
 type Provider struct {
-	// TODO: Put config fields here (with snake_case json struct tags on exported fields), for example:
+	// APIToken is the bearer token for authentication with The Little Host API.
+	// Tokens are prefixed with "tlh_" and can be generated in the control panel.
 	APIToken string `json:"api_token,omitempty"`
 
-	// Exported config fields should be JSON-serializable or omitted (`json:"-"`)
+	// ServerURL overrides the default API base URL. Leave empty to use the
+	// production endpoint (https://control.thelittlehost.com/api/v1).
+	ServerURL string `json:"server_url,omitempty"`
+
+	mu     sync.Mutex
+	client *http.Client
 }
 
-// GetRecords lists all the records in the zone.
+func (p *Provider) initClient() {
+	if p.client == nil {
+		p.client = &http.Client{Timeout: 30 * time.Second}
+	}
+	if p.ServerURL == "" {
+		p.ServerURL = "https://control.thelittlehost.com/api/v1"
+	}
+}
+
+// doRequest executes an authenticated HTTP request against The Little Host API.
+func (p *Provider) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	p.initClient()
+
+	url := p.ServerURL + "/" + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+p.APIToken)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return p.client.Do(req)
+}
+
+// readResponse reads the response body and checks the status code.
+func readResponse(resp *http.Response, wantStatuses ...int) ([]byte, error) {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	for _, s := range wantStatuses {
+		if resp.StatusCode == s {
+			return body, nil
+		}
+	}
+
+	return body, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}
+
+// unmarshalRecord decodes a single apiRecord from JSON, trying both
+// unwrapped ({"id":...}) and wrapped ({"record":{"id":...}}) formats.
+func unmarshalRecord(body []byte) (apiRecord, error) {
+	// Try unwrapped (flat object).
+	var flat apiRecord
+	if err := json.Unmarshal(body, &flat); err == nil && flat.ID != 0 {
+		return flat, nil
+	}
+
+	// Try wrapped ({"record": {...}}).
+	var wrapped struct {
+		Record apiRecord `json:"record"`
+	}
+	if err := json.Unmarshal(body, &wrapped); err == nil && wrapped.Record.ID != 0 {
+		return wrapped.Record, nil
+	}
+
+	return apiRecord{}, fmt.Errorf("decode record: unrecognized response format: %.256s", body)
+}
+
+// unFQDN strips the trailing dot from a fully qualified domain name.
+func unFQDN(zone string) string {
+	return strings.TrimSuffix(zone, ".")
+}
+
+// toLibdnsRecord converts an API record to a libdns.Record (type-specific struct).
+func toLibdnsRecord(r apiRecord) (libdns.Record, error) {
+	data := r.Value
+	if r.Type == "MX" && r.Priority != nil {
+		data = strconv.Itoa(*r.Priority) + " " + r.Value
+	}
+
+	rr := libdns.RR{
+		Name: r.Name,
+		TTL:  time.Duration(r.TTL) * time.Second,
+		Type: r.Type,
+		Data: data,
+	}
+
+	rec, err := rr.Parse()
+	if err != nil {
+		return nil, fmt.Errorf("parse record %s %q: %w", r.Type, r.Name, err)
+	}
+	return rec, nil
+}
+
+// toRecordInput converts a libdns.Record to the API input format.
+func toRecordInput(rec libdns.Record) recordInput {
+	rr := rec.RR()
+
+	input := recordInput{
+		RecordType: rr.Type,
+		Name:       rr.Name,
+		Value:      rr.Data,
+		TTL:        int(rr.TTL.Seconds()),
+	}
+
+	// MX records encode priority in Data as "preference target".
+	if rr.Type == "MX" {
+		parts := strings.SplitN(rr.Data, " ", 2)
+		if len(parts) == 2 {
+			if prio, err := strconv.Atoi(parts[0]); err == nil {
+				input.Priority = &prio
+				input.Value = parts[1]
+			}
+		}
+	}
+
+	return input
+}
+
+// apiRecordMatchesRR reports whether an API record matches a libdns RR for deletion.
+// Empty fields in rr act as wildcards per the libdns.RecordDeleter contract.
+func apiRecordMatchesRR(ar apiRecord, rr libdns.RR) bool {
+	if ar.Name != rr.Name {
+		return false
+	}
+	if rr.Type != "" && ar.Type != rr.Type {
+		return false
+	}
+	if rr.TTL != 0 && time.Duration(ar.TTL)*time.Second != rr.TTL {
+		return false
+	}
+	if rr.Data != "" {
+		apiData := ar.Value
+		if ar.Type == "MX" && ar.Priority != nil {
+			apiData = strconv.Itoa(*ar.Priority) + " " + ar.Value
+		}
+		if apiData != rr.Data {
+			return false
+		}
+	}
+	return true
+}
+
+// getAllRecords fetches all records from the zone via the API.
+func (p *Provider) getAllRecords(ctx context.Context, zone string) ([]apiRecord, error) {
+	resp, err := p.doRequest(ctx, http.MethodGet, fmt.Sprintf("zones/%s/records", zone), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list records for zone %s: %w", zone, err)
+	}
+
+	body, err := readResponse(resp, http.StatusOK)
+	if err != nil {
+		return nil, fmt.Errorf("list records for zone %s: %w", zone, err)
+	}
+
+	// Try plain array first, then wrapped {"records": [...]}.
+	var records []apiRecord
+	if err := json.Unmarshal(body, &records); err != nil {
+		var wrapped struct {
+			Records []apiRecord `json:"records"`
+		}
+		if err2 := json.Unmarshal(body, &wrapped); err2 != nil {
+			return nil, fmt.Errorf("decode records for zone %s: %w", zone, err)
+		}
+		records = wrapped.Records
+	}
+	return records, nil
+}
+
+// createRecord creates a single record in the zone via the API.
+func (p *Provider) createRecord(ctx context.Context, zone string, input recordInput) (apiRecord, error) {
+	resp, err := p.doRequest(ctx, http.MethodPost, fmt.Sprintf("zones/%s/records", zone), recordRequest{Record: input})
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("create record in zone %s: %w", zone, err)
+	}
+
+	body, err := readResponse(resp, http.StatusCreated, http.StatusOK)
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("create record in zone %s: %w", zone, err)
+	}
+
+	record, err := unmarshalRecord(body)
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("create record in zone %s: %w", zone, err)
+	}
+	return record, nil
+}
+
+// updateRecord updates a single record in the zone via the API.
+func (p *Provider) updateRecord(ctx context.Context, zone string, id int, input recordInput) (apiRecord, error) {
+	resp, err := p.doRequest(ctx, http.MethodPatch, fmt.Sprintf("zones/%s/records/%d", zone, id), recordRequest{Record: input})
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("update record %d in zone %s: %w", id, zone, err)
+	}
+
+	body, err := readResponse(resp, http.StatusOK)
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("update record %d in zone %s: %w", id, zone, err)
+	}
+
+	record, err := unmarshalRecord(body)
+	if err != nil {
+		return apiRecord{}, fmt.Errorf("update record %d in zone %s: %w", id, zone, err)
+	}
+	return record, nil
+}
+
+// deleteRecordByID deletes a single record by ID via the API.
+func (p *Provider) deleteRecordByID(ctx context.Context, zone string, id int) error {
+	resp, err := p.doRequest(ctx, http.MethodDelete, fmt.Sprintf("zones/%s/records/%d", zone, id), nil)
+	if err != nil {
+		return fmt.Errorf("delete record %d in zone %s: %w", id, zone, err)
+	}
+
+	if _, err := readResponse(resp, http.StatusNoContent); err != nil {
+		return fmt.Errorf("delete record %d in zone %s: %w", id, zone, err)
+	}
+	return nil
+}
+
+// GetRecords lists all the records in the zone. zone must be a fully-qualified
+// domain name with a trailing dot (e.g. "example.com."). Record names in the
+// returned slice are relative to the zone.
 func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	zone = unFQDN(zone)
+
+	apiRecs, err := p.getAllRecords(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]libdns.Record, 0, len(apiRecs))
+	for _, ar := range apiRecs {
+		rec, err := toLibdnsRecord(ar)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return records, nil
 }
 
-// AppendRecords adds records to the zone. It returns the records that were added.
-func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+// AppendRecords adds records to the zone without replacing any existing records.
+// It returns the records that were added. Record names must be relative to the zone.
+func (p *Provider) AppendRecords(ctx context.Context, zone string, recs []libdns.Record) ([]libdns.Record, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	zone = unFQDN(zone)
+
+	created := make([]libdns.Record, 0, len(recs))
+	for _, rec := range recs {
+		input := toRecordInput(rec)
+		ar, err := p.createRecord(ctx, zone, input)
+		if err != nil {
+			return created, err
+		}
+		libRec, err := toLibdnsRecord(ar)
+		if err != nil {
+			return created, err
+		}
+		created = append(created, libRec)
+	}
+	return created, nil
 }
 
-// SetRecords sets the records in the zone, either by updating existing records or creating new ones.
-// It returns the updated records.
-func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+// SetRecords sets the records in the zone, either by updating existing records
+// or creating new ones. For each (name, type) pair present in recs, it ensures
+// the zone contains exactly those records — surplus existing records for that
+// pair are deleted. Records for (name, type) pairs not mentioned in recs are
+// left untouched. It returns the records that were set.
+func (p *Provider) SetRecords(ctx context.Context, zone string, recs []libdns.Record) ([]libdns.Record, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	zone = unFQDN(zone)
+
+	existing, err := p.getAllRecords(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group input records by (name, type).
+	inputByKey := make(map[rrsetKey][]libdns.Record)
+	for _, rec := range recs {
+		rr := rec.RR()
+		key := rrsetKey{Name: rr.Name, Type: rr.Type}
+		inputByKey[key] = append(inputByKey[key], rec)
+	}
+
+	// Group existing API records by (name, type).
+	existingByKey := make(map[rrsetKey][]apiRecord)
+	for _, ar := range existing {
+		key := rrsetKey{Name: ar.Name, Type: ar.Type}
+		existingByKey[key] = append(existingByKey[key], ar)
+	}
+
+	var result []libdns.Record
+
+	for key, inputRecs := range inputByKey {
+		existingRecs := existingByKey[key]
+
+		// Update existing records where possible, create the rest.
+		for i, rec := range inputRecs {
+			input := toRecordInput(rec)
+			var ar apiRecord
+			if i < len(existingRecs) {
+				ar, err = p.updateRecord(ctx, zone, existingRecs[i].ID, input)
+			} else {
+				ar, err = p.createRecord(ctx, zone, input)
+			}
+			if err != nil {
+				return result, err
+			}
+			libRec, err := toLibdnsRecord(ar)
+			if err != nil {
+				return result, err
+			}
+			result = append(result, libRec)
+		}
+
+		// Delete surplus existing records not covered by input.
+		for i := len(inputRecs); i < len(existingRecs); i++ {
+			if err := p.deleteRecordByID(ctx, zone, existingRecs[i].ID); err != nil {
+				return result, err
+			}
+		}
+	}
+
+	return result, nil
 }
 
-// DeleteRecords deletes the specified records from the zone. It returns the records that were deleted.
-func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	// Make sure to return RR-type-specific structs, not libdns.RR structs.
-	return nil, fmt.Errorf("TODO: not implemented")
+// DeleteRecords deletes the specified records from the zone.
+// Records that don't exist in the zone are silently ignored.
+// Empty Type, TTL, or Data fields in the input act as wildcards.
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, recs []libdns.Record) ([]libdns.Record, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	zone = unFQDN(zone)
+
+	existing, err := p.getAllRecords(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	// Track which API record IDs have been deleted to avoid double-deletion.
+	deletedIDs := make(map[int]bool)
+
+	var deleted []libdns.Record
+	for _, rec := range recs {
+		rr := rec.RR()
+		for _, ar := range existing {
+			if deletedIDs[ar.ID] {
+				continue
+			}
+			if !apiRecordMatchesRR(ar, rr) {
+				continue
+			}
+			if err := p.deleteRecordByID(ctx, zone, ar.ID); err != nil {
+				return deleted, err
+			}
+			deletedIDs[ar.ID] = true
+			libRec, err := toLibdnsRecord(ar)
+			if err != nil {
+				return deleted, err
+			}
+			deleted = append(deleted, libRec)
+		}
+	}
+
+	return deleted, nil
 }
 
 // Interface guards

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,506 @@
+package thelittlehost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/libdns/libdns"
+)
+
+// newTestServer creates a mock API server with the given handler and returns
+// a Provider configured to use it.
+func newTestServer(t *testing.T, handler http.Handler) *Provider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &Provider{
+		APIToken:  "tlh_test_token",
+		ServerURL: srv.URL,
+	}
+}
+
+// apiHandler builds an http.ServeMux that simulates The Little Host API.
+// It stores records in memory and supports list, create, update, and delete.
+func apiHandler(t *testing.T) (*http.ServeMux, *[]apiRecord) {
+	t.Helper()
+	mux := http.NewServeMux()
+	nextID := 1
+	records := &[]apiRecord{}
+
+	// GET /zones/{zone}/records
+	mux.HandleFunc("GET /zones/{zone}/records", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(*records)
+	})
+
+	// POST /zones/{zone}/records
+	mux.HandleFunc("POST /zones/{zone}/records", func(w http.ResponseWriter, r *http.Request) {
+		var req recordRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rec := apiRecord{
+			ID:       nextID,
+			Type:     req.Record.RecordType,
+			Name:     req.Record.Name,
+			Value:    req.Record.Value,
+			TTL:      req.Record.TTL,
+			Priority: req.Record.Priority,
+		}
+		nextID++
+		*records = append(*records, rec)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(rec)
+	})
+
+	// PATCH /zones/{zone}/records/{id}
+	mux.HandleFunc("PATCH /zones/{zone}/records/{id}", func(w http.ResponseWriter, r *http.Request) {
+		idStr := r.PathValue("id")
+		var req recordRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		for i, rec := range *records {
+			if idStr == fmt.Sprintf("%d", rec.ID) {
+				if req.Record.RecordType != "" {
+					(*records)[i].Type = req.Record.RecordType
+				}
+				if req.Record.Name != "" {
+					(*records)[i].Name = req.Record.Name
+				}
+				if req.Record.Value != "" {
+					(*records)[i].Value = req.Record.Value
+				}
+				if req.Record.TTL != 0 {
+					(*records)[i].TTL = req.Record.TTL
+				}
+				(*records)[i].Priority = req.Record.Priority
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode((*records)[i])
+				return
+			}
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	// DELETE /zones/{zone}/records/{id}
+	mux.HandleFunc("DELETE /zones/{zone}/records/{id}", func(w http.ResponseWriter, r *http.Request) {
+		idStr := r.PathValue("id")
+		for i, rec := range *records {
+			if idStr == fmt.Sprintf("%d", rec.ID) {
+				*records = append((*records)[:i], (*records)[i+1:]...)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	return mux, records
+}
+
+func TestGetRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		seed     []apiRecord
+		wantLen  int
+		wantName string
+		wantType string
+	}{
+		{
+			name:    "empty zone",
+			seed:    nil,
+			wantLen: 0,
+		},
+		{
+			name: "single A record",
+			seed: []apiRecord{
+				{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+			},
+			wantLen:  1,
+			wantName: "www",
+			wantType: "A",
+		},
+		{
+			name: "multiple records",
+			seed: []apiRecord{
+				{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+				{ID: 2, Type: "CNAME", Name: "blog", Value: "example.netlify.app", TTL: 3600},
+			},
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mux, records := apiHandler(t)
+			if tt.seed != nil {
+				*records = tt.seed
+			}
+			p := newTestServer(t, mux)
+
+			got, err := p.GetRecords(context.Background(), "example.com.")
+			if err != nil {
+				t.Fatalf("GetRecords: %v", err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("got %d records, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantName != "" {
+				rr := got[0].RR()
+				if rr.Name != tt.wantName {
+					t.Errorf("name = %q, want %q", rr.Name, tt.wantName)
+				}
+			}
+			if tt.wantType != "" {
+				rr := got[0].RR()
+				if rr.Type != tt.wantType {
+					t.Errorf("type = %q, want %q", rr.Type, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendRecords(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	p := newTestServer(t, mux)
+
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "www",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("1.2.3.4"),
+		},
+	}
+
+	got, err := p.AppendRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("AppendRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server has %d records, want 1", len(*records))
+	}
+
+	rr := got[0].RR()
+	if rr.Name != "www" {
+		t.Errorf("name = %q, want %q", rr.Name, "www")
+	}
+	if rr.Type != "A" {
+		t.Errorf("type = %q, want %q", rr.Type, "A")
+	}
+}
+
+func TestSetRecords_CreateNew(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	p := newTestServer(t, mux)
+
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "www",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("1.2.3.4"),
+		},
+	}
+
+	got, err := p.SetRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("SetRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server has %d records, want 1", len(*records))
+	}
+}
+
+func TestSetRecords_UpdateExisting(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	*records = []apiRecord{
+		{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+	}
+	p := newTestServer(t, mux)
+
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "www",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("5.6.7.8"),
+		},
+	}
+
+	got, err := p.SetRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("SetRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server should still have 1 record, has %d", len(*records))
+	}
+	if (*records)[0].Value != "5.6.7.8" {
+		t.Errorf("value = %q, want %q", (*records)[0].Value, "5.6.7.8")
+	}
+}
+
+func TestSetRecords_DeleteSurplus(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	*records = []apiRecord{
+		{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+		{ID: 2, Type: "A", Name: "www", Value: "5.6.7.8", TTL: 3600},
+	}
+	p := newTestServer(t, mux)
+
+	// Set only one A record for "www" — the second should be deleted.
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "www",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("9.9.9.9"),
+		},
+	}
+
+	got, err := p.SetRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("SetRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server should have 1 record, has %d", len(*records))
+	}
+}
+
+func TestDeleteRecords(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	*records = []apiRecord{
+		{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+		{ID: 2, Type: "CNAME", Name: "blog", Value: "example.netlify.app", TTL: 3600},
+	}
+	p := newTestServer(t, mux)
+
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "www",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("1.2.3.4"),
+		},
+	}
+
+	got, err := p.DeleteRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("DeleteRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d deleted records, want 1", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server should have 1 record, has %d", len(*records))
+	}
+	if (*records)[0].Name != "blog" {
+		t.Errorf("remaining record name = %q, want %q", (*records)[0].Name, "blog")
+	}
+}
+
+func TestDeleteRecords_Nonexistent(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	*records = []apiRecord{
+		{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+	}
+	p := newTestServer(t, mux)
+
+	// Try to delete a record that doesn't exist — should be silently ignored.
+	input := []libdns.Record{
+		libdns.Address{
+			Name: "missing",
+			TTL:  3600 * time.Second,
+			IP:   netip.MustParseAddr("9.9.9.9"),
+		},
+	}
+
+	got, err := p.DeleteRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("DeleteRecords: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d deleted records, want 0", len(got))
+	}
+	if len(*records) != 1 {
+		t.Fatalf("server should still have 1 record, has %d", len(*records))
+	}
+}
+
+func TestDeleteRecords_WildcardType(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	*records = []apiRecord{
+		{ID: 1, Type: "A", Name: "www", Value: "1.2.3.4", TTL: 3600},
+		{ID: 2, Type: "AAAA", Name: "www", Value: "2001:db8::1", TTL: 3600},
+	}
+	p := newTestServer(t, mux)
+
+	// Delete all records named "www" regardless of type (empty Type acts as wildcard).
+	input := []libdns.Record{
+		libdns.RR{Name: "www"},
+	}
+
+	got, err := p.DeleteRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("DeleteRecords: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d deleted records, want 2", len(got))
+	}
+	if len(*records) != 0 {
+		t.Fatalf("server should have 0 records, has %d", len(*records))
+	}
+}
+
+func TestMXRecordConversion(t *testing.T) {
+	t.Parallel()
+	mux, _ := apiHandler(t)
+	p := newTestServer(t, mux)
+
+	input := []libdns.Record{
+		libdns.MX{
+			Name:       "@",
+			TTL:        3600 * time.Second,
+			Preference: 10,
+			Target:     "mail.example.com",
+		},
+	}
+
+	got, err := p.AppendRecords(context.Background(), "example.com.", input)
+	if err != nil {
+		t.Fatalf("AppendRecords: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+
+	rr := got[0].RR()
+	if rr.Type != "MX" {
+		t.Errorf("type = %q, want %q", rr.Type, "MX")
+	}
+	if rr.Name != "@" {
+		t.Errorf("name = %q, want %q", rr.Name, "@")
+	}
+}
+
+// TestTXTRecordRoundTrip mimics the CertMagic ACME DNS-01 flow:
+// create a TXT record, then delete it.
+func TestTXTRecordRoundTrip(t *testing.T) {
+	t.Parallel()
+	mux, records := apiHandler(t)
+	p := newTestServer(t, mux)
+
+	// CertMagic creates a TXT record for the challenge.
+	input := []libdns.Record{
+		libdns.TXT{
+			Name: "_acme-challenge.testme",
+			TTL:  120 * time.Second,
+			Text: "3X4yy4dn5TSTWXYcIanf09hbty9755qW9FLyR0175Ws",
+		},
+	}
+
+	// Present step: append the TXT record.
+	created, err := p.AppendRecords(context.Background(), "kaopeh.com.", input)
+	if err != nil {
+		t.Fatalf("AppendRecords (present): %v", err)
+	}
+	if len(created) != 1 {
+		t.Fatalf("got %d records, want 1", len(created))
+	}
+
+	rr := created[0].RR()
+	if rr.Type != "TXT" {
+		t.Errorf("type = %q, want TXT", rr.Type)
+	}
+	if rr.Name != "_acme-challenge.testme" {
+		t.Errorf("name = %q, want _acme-challenge.testme", rr.Name)
+	}
+
+	// CleanUp step: delete the TXT record.
+	deleted, err := p.DeleteRecords(context.Background(), "kaopeh.com.", created)
+	if err != nil {
+		t.Fatalf("DeleteRecords (cleanup): %v", err)
+	}
+	if len(deleted) != 1 {
+		t.Fatalf("got %d deleted, want 1", len(deleted))
+	}
+	if len(*records) != 0 {
+		t.Fatalf("server should have 0 records, has %d", len(*records))
+	}
+}
+
+func TestUnFQDN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"example.com.", "example.com"},
+		{"example.com", "example.com"},
+		{".", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			if got := unFQDN(tt.input); got != tt.want {
+				t.Errorf("unFQDN(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]apiRecord{})
+	}))
+	t.Cleanup(srv.Close)
+
+	p := &Provider{
+		APIToken:  "tlh_my_secret_token",
+		ServerURL: srv.URL,
+	}
+
+	_, err := p.GetRecords(context.Background(), "example.com.")
+	if err != nil {
+		t.Fatalf("GetRecords: %v", err)
+	}
+	if gotAuth != "Bearer tlh_my_secret_token" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer tlh_my_secret_token")
+	}
+}


### PR DESCRIPTION
This PR implements the TheLittleHost DNS Service's libdns

- libdns/libdns#217

Tested on a local xcaddy build

```
2026/03/12 13:51:18.808 INFO    authorization finalized {"identifier": "xx.com", "authz_status": "valid"}
2026/03/12 13:51:18.809 INFO    validations succeeded; finalizing order {"order": "https://acme-staging-v02.api.letsencrypt.org/acme/order/xx/xx"}
```